### PR TITLE
Deletes second entry for ww3

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -79,12 +79,5 @@ repo_url = https://github.com/ESCOMP/rtm
 local_path = components/rtm
 required = True
 
-[ww3]
-tag = release_tags/ww3_cesm2_0_rel_01
-protocol = svn
-repo_url = https://svn-ccsm-models.cgd.ucar.edu/ww3
-local_path = components/ww3
-required = True
-
 [externals_description]
 schema_version = 1.0.0


### PR DESCRIPTION
There were two entries for ww3, which causes an error when running checkout_externals.

