### PR TITLE
Add MARBL external

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # managed directories that are checked out by the externals tool
 cime/
 components/
+libraries/
 
 # generated local files
 *.log

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -42,6 +42,13 @@ repo_url = https://github.com/CVMix/CVMix-src
 local_path = libraries/CVMix
 required = True
 
+[marbl]
+tag = marbl0.34.0
+protocol = git
+repo_url = https://github.com/marbl-ecosys/MARBL
+local_path = libraries/MARBL
+required = True
+
 [mom]
 branch = master
 protocol = git


### PR DESCRIPTION
MARBL gets placed in `libraries/MARBL/`

I also, added `libraries/` to `.gitignore`


Update Externals.cfg to include MARBL

User interface changes?:
_Maybe_? Should probably update the [MOM6 quickstart](https://github.com/ESCOMP/MOM_interface/wiki/Quick-Start) to include `marbl` explicitly in `checkout_externals` call

Fixes:
No open issue ticket, but we need to add MARBL support to MOM6 and this is the first step. I'll also submit a PR to [MOM6_interface](https://github.com/ESCOMP/MOM_interface) in a few minutes to update `buildlib` to include `MARBL`.

Testing:
  manual testing: verified that the correct code ends up in `libraries/MARBL`

