### PR TITLE
Remove CVMix and MARBL from libraries/

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -81,19 +81,5 @@ local_path = libraries/FMS
 externals = Externals_FMS.cfg
 required = True
 
-[marbl]
-tag = marbl0.34.0
-protocol = git
-repo_url = https://github.com/marbl-ecosys/MARBL
-local_path = libraries/MARBL
-required = True
-
-[CVMix]
-hash = 534fc38
-protocol = git
-repo_url = https://github.com/CVMix/CVMix-src
-local_path = libraries/CVMix
-required = True
-
 [externals_description]
 schema_version = 1.0.0


### PR DESCRIPTION
Remove CVMix and MARBL from Externals.cfg

Update Externals.cfg so that CESM does not look for CVMix or MARBL - MOM and
POP will each be responsible for managing their own versions of these
libraries.

User interface changes?: No

Fixes: N/A

Testing:
  unit tests:
  system tests:
  manual testing: ensured that a case using the `CMOM` compset still builds

NOTE: This requires https://github.com/ESCOMP/MOM_interface/pull/41 otherwise MOM will not be able to find CVMix and the build will abort

